### PR TITLE
fix(generator): run user handlers before built-in handlers

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -25,7 +25,8 @@ export class Generator {
     this.components = new Components(this.rootPath)
     this.handlers = new Handlers(defaultHandlers)
 
-    if (this.config.handlers) this.handlers.push(...this.config.handlers)
+    // Prepend so user handlers take precedence over the built-in pipeline
+    if (this.config.handlers) this.handlers.unshift(...this.config.handlers)
   }
 
   get config() {


### PR DESCRIPTION
## Summary

User-supplied type handlers from `generator.handlers` are appended **after** the built-in defaults, but `Handlers.match()` returns the **first** matching handler. As a result a user handler can never override a built-in one — the documented behavior of custom handlers taking precedence does not actually happen.

## The bug

`Handlers` extends `Array` and matches first-wins:

```ts
// packages/generator/src/handlers.ts
match(type, context) {
  const text = type.getText()
  const ref = Reference.try(text)
  for (const item of this) {     // first match wins
    ...
    return item
  }
}
```

But the constructor pushes the defaults first, then **appends** user handlers:

```ts
// packages/generator/src/generator.ts
this.handlers = new Handlers(defaultHandlers)
if (this.config.handlers) this.handlers.push(...this.config.handlers)  // appended last
```

So for any type already covered by a default handler, the default matches first and the user handler is dead code.

### Concrete example

`defaultHandlers` includes a `luxon.DateTime` → `{ type: 'string' }` handler. A user handler intended to emit `{ type: 'string', format: 'date-time' }`:

```ts
const dateTimeHandler: Handler = {
  text: /^luxon\.DateTime<[^>]+>$/,
  schema: () => ({ type: 'string', format: 'date-time' }),
}
// generator: { handlers: [dateTimeHandler] }
```

never runs — the built-in `string` handler wins, and `DateTime` fields are emitted without `format: date-time`.

## Why this is a bug (not intended behavior)

The documentation already states user handlers take precedence:

- **guide/handlers** (`docs/content/2.guide/5.handlers.md`): *"They run **before** the built-in handlers, so you can override default behavior (e.g. emit `DateTime` as `date-time` instead of plain `string`)."*
- **guide/configuration**, `generator.handlers` (`docs/content/2.guide/1.configuration.md`): *"Extra type → schema handlers, **prepended** to the built-in pipeline ... or to override defaults (e.g. emit `DateTime` as `date-time`)."*

The code does the opposite of "prepended" / "run before".

## Fix

Prepend user handlers with `unshift` so they match before the built-ins, matching the documented contract:

```diff
- if (this.config.handlers) this.handlers.push(...this.config.handlers)
+ if (this.config.handlers) this.handlers.unshift(...this.config.handlers)
```

This preserves the relative order of multiple user handlers and only moves them ahead of the defaults.

## Testing

Verified end-to-end in a downstream AdonisJS 7 app: with the change applied, the custom `luxon.DateTime` handler overrides the built-in and the generated spec emits `{ "type": "string", "format": "date-time" }` for `DateTime` columns. (We've been running this exact change as a local `pnpm` patch against `1.0.7` and it produces a correct spec.)

The repo currently has no test suite (empty `vitest.config.ts`, no spec files), so no tests were added; happy to add coverage for handler precedence if you'd like a pattern established.
